### PR TITLE
fix: enable service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh" class="overflow-hidden overscroll-none font-sans">
+<html lang="zh" class="font-sans overflow-hidden overscroll-none">
 
 <head>
   <meta charset="UTF-8" />
@@ -12,6 +12,7 @@
 <body>
   <div id="react-app"></div>
   <script type="module" src="./src/main.tsx"></script>
+  <script src="./registerSW.js"></script>
 </body>
 
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,8 @@ import react from "@vitejs/plugin-react"
 import { VitePWA } from 'vite-plugin-pwa'
 
 export default defineConfig(({ command }) => {
+  const isProduction = "production" === process.env.NODE_ENV
+
   const preactAlias = command === "build"
     ? [
       { find: "react", replacement: "preact/compat" },
@@ -20,7 +22,16 @@ export default defineConfig(({ command }) => {
     },
     plugins: [
       react(),
-      VitePWA,
+      VitePWA({
+        mode: isProduction ? "production" : "development",
+        base: "/",
+        registerType: "autoUpdate",
+        workbox: {
+          cacheId: "pic-asoul-fan-cache",
+          disableDevLogs: isProduction,
+          runtimeCaching: []
+        },
+      }),
     ],
     build: {
       target: "esnext"


### PR DESCRIPTION
修复了之前 Service Worker 不工作的问题

- registerSW.js 是由 vite-plugin-pwa 自动生成的，所以开发过程可能会报找不到文件，**这个问题可以忽略**
- 由于没有配置 manifest , **所以 PWA 功能目前还不可用**，可以之后在 `VitePWA` 中配置